### PR TITLE
PATCH:fix jobs-index-showing error

### DIFF
--- a/src/components/JobSection/JobSection.jsx
+++ b/src/components/JobSection/JobSection.jsx
@@ -197,7 +197,8 @@ const JobSection = () => {
         <div className="container">
           <div className="row">
             <p className="resultShowing">
-              showing {jobsVisible} of {jobs.length} total results
+              showing {jobsVisible > jobs.length ?
+                jobs.length : jobsVisible} of {jobs.length} total results
             </p>
             {jobs.slice(0, jobsVisible).map((job, i) => {
               return (


### PR DESCRIPTION
Fixed the "Showing nth of total jobs" issue.
<img width="447" alt="image" src="https://user-images.githubusercontent.com/42496280/215251825-617f5bae-95bc-4e0f-b1b1-c3072bb4dce8.png">
